### PR TITLE
Fix the promise of the GoogleTokenVerifier

### DIFF
--- a/example/js/demo.js
+++ b/example/js/demo.js
@@ -17,7 +17,7 @@ angular.module('demo', ['googleOauth']).
     });
   }).
 
-  controller('DemoCtrl', function($scope, $window, Token) {
+  controller('DemoCtrl', function($rootScope, $scope, $window, Token) {
     $scope.accessToken = Token.get();
 
     $scope.authenticate = function() {
@@ -29,10 +29,12 @@ angular.module('demo', ['googleOauth']).
           // Verify the token before setting it, to avoid the confused deputy problem.
           Token.verifyAsync(params.access_token).
             then(function(data) {
-              $scope.accessToken = params.access_token;
-              $scope.expiresIn = params.expires_in;
+              $rootScope.$apply(function() {
+                $scope.accessToken = params.access_token;
+                $scope.expiresIn = params.expires_in;
 
-              Token.set(params.access_token);
+                Token.set(params.access_token);
+              });
             }, function() {
               alert("Failed to verify token.")
             });

--- a/src/js/angularOauth.js
+++ b/src/js/angularOauth.js
@@ -115,9 +115,7 @@ angular.module('angularOauth', []).
          *      `status`, `headers`, `config`).
          */
         verifyAsync: function(accessToken) {
-          var deferred = $q.defer();
-          config.verifyFunc(config, accessToken, deferred);
-          return deferred.promise;
+          return config.verifyFunc(config, accessToken);
         },
 
         /**

--- a/src/js/googleOauth.js
+++ b/src/js/googleOauth.js
@@ -8,9 +8,10 @@
  */
 angular.module('googleOauth', ['angularOauth']).
 
-  constant('GoogleTokenVerifier', function(config, accessToken, deferred) {
+  constant('GoogleTokenVerifier', function(config, accessToken) {
     var $injector = angular.injector(['ng']);
-    return $injector.invoke(['$http', '$rootScope', function($http, $rootScope) {
+    return $injector.invoke(['$http', '$rootScope', '$q', function($http, $rootScope, $q) {
+      var deferred = $q.defer();
       var verificationEndpoint = 'https://www.googleapis.com/oauth2/v1/tokeninfo';
 
       $rootScope.$apply(function() {
@@ -33,7 +34,7 @@ angular.module('googleOauth', ['angularOauth']).
           });
       });
 
-      return deferred;
+      return deferred.promise;
     }]);
   }).
 


### PR DESCRIPTION
- Move the $deferred object to GoogleTokenVerifier and inside $injector.invoke and return directly $deferred.promise
- Update the demo to call $rootScope.$apply inside the verifyAsync then()

Closes #1, #8
