### PR TITLE
Allow configurable response type

### DIFF
--- a/src/js/angularOauth.js
+++ b/src/js/angularOauth.js
@@ -69,7 +69,7 @@ angular.module('angularOauth', []).
         // TODO: Facebook uses comma-delimited scopes. This is not compliant with section 3.3 but perhaps support later.
 
         return {
-          response_type: RESPONSE_TYPE,
+          response_type: config.responseType || RESPONSE_TYPE,
           client_id: config.clientId,
           redirect_uri: config.redirectUri,
           scope: config.scopes.join(" ")


### PR DESCRIPTION
Hi, I'm using angular-oauth to connect my app using LinkedIn Oauth and I've realized those guys don't use the standard response_type 'token', but 'code' (https://developer.linkedin.com/documents/authentication)

This is a tiny PR to allow response_type to be configurable thru `extendConfig` method.

Thanks
