### PR TITLE
Use JQuery originalEvent if present

### DIFF
--- a/src/js/angularOauth.js
+++ b/src/js/angularOauth.js
@@ -168,6 +168,8 @@ angular.module('angularOauth', []).
           // TODO: binding occurs for each reauthentication, leading to leaks for long-running apps.
 
           angular.element($window).bind('message', function(event) {
+            // Use JQuery originalEvent if present
+            event = event.originalEvent || event;
             if (event.source == popup && event.origin == window.location.origin) {
               $rootScope.$apply(function() {
                 if (event.data.access_token) {


### PR DESCRIPTION
I had the same issue as https://github.com/enginous/angular-oauth/issues/7, because I included JQuery before angular, so it replaces the event object with a JQuery event.

Same as this change: https://github.com/angular/angular.js/pull/3556
