### PR TITLE
Safer way to parse Key Value from Query string

### DIFF
--- a/src/js/angularOauth.js
+++ b/src/js/angularOauth.js
@@ -214,9 +214,9 @@ angular.module('angularOauth', []).
       angular.forEach((keyValue || "").split('&'), function(keyValue){
         if (keyValue) {
           pos = keyValue.indexOf("=");
-					key = decodeURIComponent(keyValue.substr(0, pos));
-					key_value = keyValue.substr(pos + 1);
-					obj[key] = key_value ? decodeURIComponent(key_value) : true;
+          key = decodeURIComponent(keyValue.substr(0, pos));
+          key_value = keyValue.substr(pos + 1);
+          obj[key] = key_value ? decodeURIComponent(key_value) : true;
         }
       });
       return obj;


### PR DESCRIPTION
We have a case where access_token has "=" in it, the split("=") approach was breaking it. this should work in all cases.
