### PR TITLE
Perform OAuth flow in same window

### DIFF
--- a/src/js/angularOauth.js
+++ b/src/js/angularOauth.js
@@ -76,6 +76,11 @@ angular.module('angularOauth', []).
         }
       };
 
+      var buildAuthorizationUrl = function(extraParams) {
+        var params = angular.extend(getParams(), extraParams);
+        return config.authorizationEndpoint + '?' + objectToQueryString(params);
+      }
+
       return {
         // TODO: get/set might want to support expiration to reauthenticate
         // TODO: check for localStorage support and otherwise perhaps use other methods of storing data (e.g. cookie)
@@ -155,8 +160,7 @@ angular.module('angularOauth', []).
           }, popupOptions);
 
           var deferred = $q.defer(),
-            params = angular.extend(getParams(), extraParams),
-            url = config.authorizationEndpoint + '?' + objectToQueryString(params),
+            url = buildAuthorizationUrl(extraParams),
             resolved = false;
 
           var formatPopupOptions = function(options) {
@@ -191,6 +195,10 @@ angular.module('angularOauth', []).
           // TODO: reject deferred if the popup was closed without a message being delivered + maybe offer a timeout
 
           return deferred.promise;
+        },
+        getTokenInSameWindow: function(extraParams) {
+          var url = buildAuthorizationUrl(extraParams);
+          $window.location.href = url;
         }
       }
     }


### PR DESCRIPTION
This part is actually quite simple. I had to rearrange some of my application to cope with the different workflow.

I created an endpoint in my app, `/oauth/callback`, and an `OAuthCallbackController` to handle it. Then I created a simple HTML file for my redirect URI, similar to `oauth2callback.html` but instead of loading Angular, it simply manipulates the URL to make it compatible with "hashbang" routing and pass it along to the Angular endpoint:

``` javascript
location.replace('/#/oauth/callback?' + location.hash.slice(1));
```

Then I'm able to access the OAuth params from my controller, set the token and all that good stuff:

``` javascript
  .controller('OAuthCallbackController',
    function($scope, $rootScope, $location, $injector, VgerCredentials, Token, $timeout, flash, User, UserTrackingId) {
      var params = $location.search();
      Token.verifyAsync(params.access_token).
        then(function(data) { ... }
    });
```
